### PR TITLE
Add make test script and workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+#
+# See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: C CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: make test
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.dSYM/
+.test.*words
+.sw[a-zA-Z0-9]
+.*.sw[a-zA-Z0-9]*

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@
 
 CHMOD= chmod
 CP= cp
+DIFF= diff
 INSTALL= install
 MV= mv
 RM= rm
@@ -69,6 +70,11 @@ sort: polite.english.words.txt
 	    ${RM} -f "$$TMP" ; \
 	    LC_ALL=C ${SORT} -d -f polite.english.words.txt | ${UNIQ} > "$$TMP" ; \
 	    ${MV} -f "$$TMP" polite.english.words.txt
+
+# like sort but compares output with the sorted and current, for workflows on
+# GitHub
+test: test.sh
+	@./test.sh
 
 ###################################
 # standard Makefile utility rules #

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+export WORDS="polite.english.words.txt"
+if [[ ! -f "$WORDS" ]]; then
+    echo "$0: ERROR: file does not exist: $WORDS" 1>&2
+    exit 1
+elif [[ ! -r "$WORDS" ]]; then
+    echo "$0: ERROR: file is not readable: $WORDS" 1>&2
+    exit 1
+elif [[ ! -w "$WORDS" ]]; then
+    echo "$0: ERROR: file is not writable: $WORDS" 1>&2
+    exit 1
+fi
+
+# setup a working directory unless -w was given
+#
+TMP_WORDS=$(mktemp .test.XXXXXXXXXX.words)
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: mktemp .test.XXXXXXXXXX.words exit code: $status" 1>&2
+    exit 2
+fi
+
+# trap to remove temp words list
+#
+trap "rm -rf \$TMP_WORDS; exit" 1 2 3 15
+
+# sort words list into temp list file
+#
+LC_ALL=C sort -d -f "$WORDS" | uniq > "$TMP_WORDS"
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: sort -d -f $WORDS | uniq > $TMP_WORDS failed: $status" 1>&2
+    # make sure to temp words list no longer exists
+    #
+    rm -f "$TMP_WORDS"
+    exit 1
+fi
+
+if ! diff "$TMP_WORDS" "$WORDS"; then
+    echo "$0: ERROR: words list not the same as the sorted list" 1>&2
+    echo "$0: Tip: try make sort" 1>&2
+    # make sure to temp words list no longer exists
+    #
+    rm -f "$TMP_WORDS"
+    exit 1
+fi
+
+# remove temp words list
+#
+rm -f "$TMP_WORDS"
+
+# All Done!!! All Done!!! -- Jessica Noll, Age 2
+#
+
+exit 0


### PR DESCRIPTION
This will hopefully flag the case where someone forgets to run make sort prior to committing.

Of course it is possible that there is a syntax error in the yml files and if so I will fix those (though they are copies from mkiocccentry modified for this repo).

The test.sh is very simple: create a temp words list, sort the words list into it (like the make sort rule does) and then compare it to the words list itself: if they differ it's an error, otherwise it is success (exit 0).

If it is different it suggests make sort and then exists non-zero.